### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fluent::Plugin::Http::Status
+# Fluent::Plugin::Http::Status, a plugin for [Fluentd](http://fluentd.org)
 
 Fluentd input plugin for to get the http status.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
